### PR TITLE
修复操作日志消费两次的bug

### DIFF
--- a/mate-core/mate-starter-log/src/main/java/vip/mate/core/log/event/LogListener.java
+++ b/mate-core/mate-starter-log/src/main/java/vip/mate/core/log/event/LogListener.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
 import vip.mate.core.common.dto.CommonLog;
 import vip.mate.core.log.feign.ICommonLogProvider;
 import vip.mate.core.log.feign.ISysLogProvider;
@@ -17,7 +16,6 @@ import vip.mate.core.log.props.LogType;
  * @since 2020-7-15
  */
 @Slf4j
-@Component
 public class LogListener {
 
     private ISysLogProvider sysLogProvider;


### PR DESCRIPTION
`@Component` 会被扫描并创建（前提能扫描得到的话，这里我在启动类加了`@ComponentScan({"vip.mate.*"})`）
而[LogConfiguration](https://github.com/matevip/matecloud/blob/dev/mate-core/mate-starter-log/src/main/java/vip/mate/core/log/config/LogConfiguration.java)配置了Bean LogListener，所以可能会初始化两次，从而造成消费两次。

解决方法：去掉`@Component`注解即可

![修复操作日志消费两次的bug](https://img30.360buyimg.com/pop/jfs/t1/216371/6/10077/158052/61d4e3adE4931d8c6/140e919c0b4371b0.png)